### PR TITLE
Dropped dependency on Anaconda tools and channels.

### DIFF
--- a/environments/extras.yml
+++ b/environments/extras.yml
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - biopython
   - matplotlib

--- a/environments/illumina/Singularity
+++ b/environments/illumina/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: continuumio/miniconda3:latest
+From: condaforge/miniforge3:latest
 Stage: condabuild
 %files
 environments/illumina/environment.yml /environment.yml
@@ -9,10 +9,7 @@ authors="Matt Bull"
 description="Docker image containing all requirements for the ARTIC project's ncov2019 pipeline"
 %post
 
-/opt/conda/bin/conda install mamba -c conda-forge && \
-/opt/conda/bin/mamba env create -f /environment.yml #&& \
-#/opt/conda/bin/mamba env update -f /extras.yml -n artic-ncov2019-illumina
-
+conda env create -f /environment.yml
 
 Bootstrap: docker
 From: debian:buster-slim

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -1,9 +1,7 @@
 name: artic-ncov2019-illumina
 channels:
-  - https://dnap.cog.sanger.ac.uk/npg/conda/prod/generic
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3
   - biopython=1.74

--- a/environments/nanopore/Singularity
+++ b/environments/nanopore/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: continuumio/miniconda3:latest
+From: condaforge/miniforge3:latest
 Stage: condabuild
 %files
 environments/nanopore/environment.yml /environment.yml
@@ -10,9 +10,7 @@ authors="Matt Bull"
 description="Docker image containing all requirements for the ARTIC project's ncov2019 pipeline"
 
 %post
-/opt/conda/bin/conda install mamba -c conda-forge && \
-/opt/conda/bin/mamba env create -f /environment.yml #&& \
-#/opt/conda/bin/mamba env update -f /extras.yml -n artic
+conda env create -f /environment.yml
 
 Bootstrap: docker
 From: debian:buster-slim

--- a/environments/nanopore/environment.yml
+++ b/environments/nanopore/environment.yml
@@ -2,7 +2,6 @@ name: artic
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - artic=1.1.3
   - pyyaml=5.3.1


### PR DESCRIPTION
Dropped Anaconda tools and channels from the build, replaced with conda-forge.

Excluded https://dnap.cog.sanger.ac.uk/npg/conda/prod/generic channel from build for Illumina platform since samtools=1.14, which was sourced from this channel, is now available in the bioconda channel.