### PR TITLE
Dropped dependency on Anaconda tools for docker builds

### DIFF
--- a/environments/illumina/Dockerfile
+++ b/environments/illumina/Dockerfile
@@ -1,12 +1,11 @@
-FROM continuumio/miniconda3:latest AS condabuild
+FROM condaforge/miniforge3:latest AS condabuild
 LABEL authors="Matt Bull" \
       description="Docker image containing all requirements for an Illumina ncov2019 pipeline"
 
 COPY environments/extras.yml /extras.yml
 COPY environments/illumina/environment.yml /environment.yml
-RUN /opt/conda/bin/conda update conda && \
-/opt/conda/bin/conda install mamba -c conda-forge && \
-/opt/conda/bin/mamba env create -f /environment.yml
+
+RUN conda env create -f /environment.yml
 
 FROM debian:buster-slim
 RUN apt-get update && \

--- a/environments/nanopore/Dockerfile
+++ b/environments/nanopore/Dockerfile
@@ -1,11 +1,11 @@
-FROM continuumio/miniconda3:latest AS condabuild
+FROM condaforge/miniforge3:latest AS condabuild
 LABEL authors="Matt Bull" \
       description="Docker image containing all requirements for the ARTIC project's ncov2019 pipeline"
 
 COPY environments/extras.yml /extras.yml
 COPY environments/nanopore/environment.yml /environment.yml
-RUN /opt/conda/bin/conda install mamba -c conda-forge && \
-/opt/conda/bin/mamba env create -f /environment.yml
+
+RUN conda env create -f /environment.yml
 
 FROM debian:buster-slim
 RUN apt-get update && \


### PR DESCRIPTION
Dropped Anaconda tools from the docker builds,
replaced with conda-forge.